### PR TITLE
refactor: remove duplicate line of code

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -12,7 +12,6 @@ void main() async {
   WidgetsFlutterBinding.ensureInitialized();
   await dotenv.load();
 
-  await dotenv.load(fileName: '.env');
   await setupDependencies();
 
   if (kDebugMode) {


### PR DESCRIPTION
## Scope

[No Ticket]()

I removed the duplicate code line because `dotenv.load()` automatically loads the `.env` file by default, making the additional call redundant.