### PR TITLE
fix: resolve navbar overlapping last item in list

### DIFF
--- a/lib/ui/shared/hypha_body_widget.dart
+++ b/lib/ui/shared/hypha_body_widget.dart
@@ -27,19 +27,21 @@ class HyphaBodyWidget extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Builder(
-      builder: (context) {
-        switch (pageState) {
-          case PageState.initial:
-            return initial?.call(context) ?? const SizedBox.shrink();
-          case PageState.loading:
-            return loading?.call(context) ?? const Center(child: CircularProgressIndicator.adaptive());
-          case PageState.failure:
-            return failure?.call(context) ?? const HyphaErrorWidget();
-          case PageState.success:
-            return GestureDetector(onTap: () => FocusScope.of(context).unfocus(), child: success(context));
-        }
-      },
+    return SafeArea(
+      child: Builder(
+        builder: (context) {
+          switch (pageState) {
+            case PageState.initial:
+              return initial?.call(context) ?? const SizedBox.shrink();
+            case PageState.loading:
+              return loading?.call(context) ?? const Center(child: CircularProgressIndicator.adaptive());
+            case PageState.failure:
+              return failure?.call(context) ?? const HyphaErrorWidget();
+            case PageState.success:
+              return GestureDetector(onTap: () => FocusScope.of(context).unfocus(), child: success(context));
+          }
+        },
+      ),
     );
   }
 }


### PR DESCRIPTION
## Scope
Fixed an issue in the History Transaction screen where the bottom navigation bar was overlapping the last item in the list.
## Screenshots
Before            |  After
:-------------------------:|:-------------------------:
![before](https://github.com/user-attachments/assets/847301a2-7531-49e1-8104-d4d94944f85c)  |  ![after](https://github.com/user-attachments/assets/e7d9e656-f805-4f54-9862-ef5b665ef1da)