### PR TITLE
fix: set AppBar scrolledUnderElevation to 0

### DIFF
--- a/lib/ui/history/details/components/transaction_detail_view.dart
+++ b/lib/ui/history/details/components/transaction_detail_view.dart
@@ -21,6 +21,7 @@ class TransactionDetailView extends StatelessWidget {
           child: Scaffold(
             backgroundColor: HyphaColors.transparent,
             appBar: AppBar(
+              scrolledUnderElevation: 0,
               centerTitle: true,
               title: Text('Transaction Details', style: context.hyphaTextTheme.smallTitles),
               backgroundColor: HyphaColors.transparent,


### PR DESCRIPTION
## Scope

[Ticket](https://github.com/hypha-dao/hypha-wallet/issues/294)

I fixed the issue by setting `scrolledUnderElevation` to `0`, which prevents the `AppBar` color from changing when scrolling on the transaction details page.

## Screenshots
Before            |  After
:-------------------------:|:-------------------------:
![before](https://github.com/user-attachments/assets/eead9d79-b6e6-4539-b0b0-9b62d68cc099)  |  ![after](https://github.com/user-attachments/assets/e31ec677-ae05-44d5-a1c3-5e2210b999d4)