### PR TITLE
fix: status bar icon brightness for iOS light mode

### DIFF
--- a/lib/design/themes/hypha_theme.dart
+++ b/lib/design/themes/hypha_theme.dart
@@ -61,7 +61,7 @@ class HyphaTheme {
         systemOverlayStyle: const SystemUiOverlayStyle(
           // Status bar brightness (optional)
           statusBarIconBrightness: Brightness.light, // For Android (light icons)
-          statusBarBrightness: Brightness.dark, // For iOS (light icons)
+          statusBarBrightness: Brightness.light, // For iOS (dark icons)
         ),
       ),
       bottomNavigationBarTheme: AppBottomNavigationTheme.bottomNavigationThemeData(lightColorScheme),


### PR DESCRIPTION
## Scope

[Ticket](https://github.com/hypha-dao/hypha-wallet/issues/298)

I set `statusBarBrightness` to `Brightness.light` for the `iOS light theme` to make the status bar icons dark.

## Screenshots
Before            |  After
:-------------------------:|:-------------------------:
![before](https://github.com/user-attachments/assets/17aaeede-7f4f-45ca-80b7-87dde96a7920)  |  ![after](https://github.com/user-attachments/assets/82e6845c-cb3f-4981-b168-7a00ba4fff1f)
