### PR TITLE
fix: filter proposals

### DIFF
--- a/lib/core/di/bloc_module.dart
+++ b/lib/core/di/bloc_module.dart
@@ -144,7 +144,6 @@ void _registerBlocsModule() {
     _getIt<ProposalsBloc>(),
     _getIt<FetchProfileUseCase>(),
     _getIt<AggregateDaoProposalCountsUseCase>(),
-    _getIt<GetDaosFromProposalCountsUseCase>(),
     _getIt<ErrorHandlerManager>(),
   ));
 }

--- a/lib/core/extension/proposals_filter_extension.dart
+++ b/lib/core/extension/proposals_filter_extension.dart
@@ -1,0 +1,7 @@
+import 'package:hypha_wallet/core/network/models/proposal_model.dart';
+
+extension ProposalFilterExtension on List<ProposalModel> {
+  List<ProposalModel> filterByDao(List<int> daoIds) {
+    return where((proposal) => daoIds.contains(proposal.dao?.docId)).toList();
+  }
+}

--- a/lib/ui/proposals/filter/components/filter_proposals_view.dart
+++ b/lib/ui/proposals/filter/components/filter_proposals_view.dart
@@ -74,7 +74,8 @@ class FilterProposalsView extends StatelessWidget {
                   HyphaAppButton(
                     title: 'SAVE FILTERS',
                     onPressed: () {
-                      filterProposalsBloc.add(FilterProposalsEvent.saveFilters(filterProposalsBloc.selectedDaoIndexNotifier.value == null ? state.daoProposalCounts: [state.daoProposalCounts[filterProposalsBloc.selectedDaoIndexNotifier.value!]], filterProposalsBloc.selectedStatusIndexNotifier.value == 0 ? FilterStatus.active : FilterStatus.past));
+                      final int? index = filterProposalsBloc.selectedDaoIndexNotifier.value;
+                      filterProposalsBloc.add(FilterProposalsEvent.saveFilters(index == null ? state.daoProposalCounts : [state.daoProposalCounts[index]], filterProposalsBloc.selectedStatusIndexNotifier.value == 0 ? FilterStatus.active : FilterStatus.past));
                     },
                   ),
                   const SizedBox(

--- a/lib/ui/proposals/filter/components/hypha_filter_card.dart
+++ b/lib/ui/proposals/filter/components/hypha_filter_card.dart
@@ -1,11 +1,9 @@
 import 'package:flutter/material.dart';
 import 'package:hypha_wallet/core/network/models/dao_data_model.dart';
-import 'package:hypha_wallet/design/avatar_image/hypha_avatar_image.dart';
+import 'package:hypha_wallet/design/dao_image.dart';
 import 'package:hypha_wallet/design/hypha_card.dart';
 import 'package:hypha_wallet/design/hypha_colors.dart';
-import 'package:hypha_wallet/design/ipfs_image.dart';
 import 'package:hypha_wallet/design/themes/extensions/theme_extension_provider.dart';
-import 'package:hypha_wallet/design/dao_image.dart';
 
 class HyphaFilterCard extends StatelessWidget {
   final DaoData? dao;
@@ -21,7 +19,7 @@ class HyphaFilterCard extends StatelessWidget {
     // TODO(Saif): fix the card height (filter by status)
     return GestureDetector(
       onTap: () {
-        valueNotifier.value = index;
+        valueNotifier.value = valueNotifier.value == index ? null : index;
       },
       child: HyphaCard(
           child: Padding(

--- a/lib/ui/proposals/filter/usecases/aggregate_dao_proposal_counts_use_case.dart
+++ b/lib/ui/proposals/filter/usecases/aggregate_dao_proposal_counts_use_case.dart
@@ -20,8 +20,9 @@ class AggregateDaoProposalCountsUseCase {
       }
     }
 
-    return daoProposalCounts.entries
-        .map((entry) => DaoProposalCountEntity(entry.key, entry.value))
-        .toList();
+    final List<MapEntry<DaoData, int>> sortedEntries = daoProposalCounts.entries.toList()
+      ..sort((a, b) => a.key.settingsDaoTitle.compareTo(b.key.settingsDaoTitle));
+
+    return sortedEntries.map((entry) => DaoProposalCountEntity(entry.key, entry.value)).toList();
   }
 }

--- a/lib/ui/proposals/filter/usecases/get_daos_from_proposal_counts_use_case.dart
+++ b/lib/ui/proposals/filter/usecases/get_daos_from_proposal_counts_use_case.dart
@@ -1,8 +1,0 @@
-import 'package:hypha_wallet/core/network/models/dao_data_model.dart';
-import 'package:hypha_wallet/ui/proposals/filter/interactor/dao_proposal_count_entity.dart';
-
-class GetDaosFromProposalCountsUseCase {
-  List<DaoData> run(List<DaoProposalCountEntity> daoProposalCounts) {
-    return daoProposalCounts.map((entity) => entity.dao).toList();
-  }
-}

--- a/lib/ui/proposals/list/components/proposals_view.dart
+++ b/lib/ui/proposals/list/components/proposals_view.dart
@@ -1,6 +1,9 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:get/get.dart' as GetX;
+import 'package:get_it/get_it.dart';
+import 'package:hypha_wallet/core/extension/proposals_filter_extension.dart';
+import 'package:hypha_wallet/core/network/models/proposal_model.dart';
 import 'package:hypha_wallet/design/avatar_image/hypha_avatar_image.dart';
 import 'package:hypha_wallet/design/background/hypha_page_background.dart';
 import 'package:hypha_wallet/design/hypha_colors.dart';
@@ -84,36 +87,40 @@ class ProposalsView extends StatelessWidget {
                   ),
                   child: HyphaBodyWidget(
                     pageState: state.pageState,
-                    success: (context) => Padding(
-                      padding: const EdgeInsets.symmetric(horizontal: 22),
-                      child: Column(
-                        crossAxisAlignment: CrossAxisAlignment.start,
-                        children: [
-                          const SizedBox(
-                            height: 22,
-                          ),
-                          Text(
-                            '${state.proposals.length} ${context.read<ProposalsBloc>().filterStatus.string} Proposal${state.proposals.length == 1 ? '' : 's'}',
-                            style: context.hyphaTextTheme.ralMediumBody
-                                .copyWith(color: HyphaColors.midGrey),
-                          ),
-                          const SizedBox(
-                            height: 20,
-                          ),
-                          Expanded(
-                              child: ListView.separated(
-                                  padding: const EdgeInsets.only(bottom: 22),
-                                  itemBuilder: (BuildContext context,
-                                          int index) =>
-                                      HyphaProposalsActionCard(state.proposals[index]),
-                                  separatorBuilder:
-                                      (BuildContext context, int index) {
-                                    return const SizedBox(height: 16);
-                                  },
-                                  itemCount: state.proposals.length)),
-                        ],
-                      ),
-                    ),
+                    success: (context) {
+                      final List<int>? daoIds = GetIt.I.get<FilterProposalsBloc>().daoIds;
+                      final List<ProposalModel> proposals = daoIds != null ? state.proposals.filterByDao(daoIds) : state.proposals;
+                      return Padding(
+                        padding: const EdgeInsets.symmetric(horizontal: 22),
+                        child: Column(
+                          crossAxisAlignment: CrossAxisAlignment.start,
+                          children: [
+                            const SizedBox(
+                              height: 22,
+                            ),
+                            Text(
+                              '${proposals.length} ${context.read<ProposalsBloc>().filterStatus.string} Proposal${proposals.length == 1 ? '' : 's'}',
+                              style: context.hyphaTextTheme.ralMediumBody
+                                  .copyWith(color: HyphaColors.midGrey),
+                            ),
+                            const SizedBox(
+                              height: 20,
+                            ),
+                            Expanded(
+                                child: ListView.separated(
+                                    padding: const EdgeInsets.only(bottom: 22),
+                                    itemBuilder: (BuildContext context,
+                                        int index) =>
+                                        HyphaProposalsActionCard(proposals[index]),
+                                    separatorBuilder:
+                                        (BuildContext context, int index) {
+                                      return const SizedBox(height: 16);
+                                    },
+                                    itemCount: proposals.length)),
+                          ],
+                        ),
+                      );
+                    },
                   ),
                 )),
             floatingActionButton: IconButton(

--- a/lib/ui/proposals/list/interactor/proposals_bloc.freezed.dart
+++ b/lib/ui/proposals/list/interactor/proposals_bloc.freezed.dart
@@ -17,27 +17,20 @@ final _privateConstructorUsedError = UnsupportedError(
 /// @nodoc
 mixin _$ProposalsEvent {
   bool get refresh => throw _privateConstructorUsedError;
-  List<DaoData>? get daos => throw _privateConstructorUsedError;
   FilterStatus get filterStatus => throw _privateConstructorUsedError;
   @optionalTypeArgs
   TResult when<TResult extends Object?>({
-    required TResult Function(
-            bool refresh, List<DaoData>? daos, FilterStatus filterStatus)
-        initial,
+    required TResult Function(bool refresh, FilterStatus filterStatus) initial,
   }) =>
       throw _privateConstructorUsedError;
   @optionalTypeArgs
   TResult? whenOrNull<TResult extends Object?>({
-    TResult? Function(
-            bool refresh, List<DaoData>? daos, FilterStatus filterStatus)?
-        initial,
+    TResult? Function(bool refresh, FilterStatus filterStatus)? initial,
   }) =>
       throw _privateConstructorUsedError;
   @optionalTypeArgs
   TResult maybeWhen<TResult extends Object?>({
-    TResult Function(
-            bool refresh, List<DaoData>? daos, FilterStatus filterStatus)?
-        initial,
+    TResult Function(bool refresh, FilterStatus filterStatus)? initial,
     required TResult orElse(),
   }) =>
       throw _privateConstructorUsedError;
@@ -71,7 +64,7 @@ abstract class $ProposalsEventCopyWith<$Res> {
           ProposalsEvent value, $Res Function(ProposalsEvent) then) =
       _$ProposalsEventCopyWithImpl<$Res, ProposalsEvent>;
   @useResult
-  $Res call({bool refresh, List<DaoData>? daos, FilterStatus filterStatus});
+  $Res call({bool refresh, FilterStatus filterStatus});
 }
 
 /// @nodoc
@@ -90,7 +83,6 @@ class _$ProposalsEventCopyWithImpl<$Res, $Val extends ProposalsEvent>
   @override
   $Res call({
     Object? refresh = null,
-    Object? daos = freezed,
     Object? filterStatus = null,
   }) {
     return _then(_value.copyWith(
@@ -98,10 +90,6 @@ class _$ProposalsEventCopyWithImpl<$Res, $Val extends ProposalsEvent>
           ? _value.refresh
           : refresh // ignore: cast_nullable_to_non_nullable
               as bool,
-      daos: freezed == daos
-          ? _value.daos
-          : daos // ignore: cast_nullable_to_non_nullable
-              as List<DaoData>?,
       filterStatus: null == filterStatus
           ? _value.filterStatus
           : filterStatus // ignore: cast_nullable_to_non_nullable
@@ -118,7 +106,7 @@ abstract class _$$InitialImplCopyWith<$Res>
       __$$InitialImplCopyWithImpl<$Res>;
   @override
   @useResult
-  $Res call({bool refresh, List<DaoData>? daos, FilterStatus filterStatus});
+  $Res call({bool refresh, FilterStatus filterStatus});
 }
 
 /// @nodoc
@@ -135,7 +123,6 @@ class __$$InitialImplCopyWithImpl<$Res>
   @override
   $Res call({
     Object? refresh = null,
-    Object? daos = freezed,
     Object? filterStatus = null,
   }) {
     return _then(_$InitialImpl(
@@ -143,10 +130,6 @@ class __$$InitialImplCopyWithImpl<$Res>
           ? _value.refresh
           : refresh // ignore: cast_nullable_to_non_nullable
               as bool,
-      daos: freezed == daos
-          ? _value._daos
-          : daos // ignore: cast_nullable_to_non_nullable
-              as List<DaoData>?,
       filterStatus: null == filterStatus
           ? _value.filterStatus
           : filterStatus // ignore: cast_nullable_to_non_nullable
@@ -159,31 +142,18 @@ class __$$InitialImplCopyWithImpl<$Res>
 
 class _$InitialImpl implements _Initial {
   const _$InitialImpl(
-      {this.refresh = false,
-      final List<DaoData>? daos,
-      this.filterStatus = FilterStatus.active})
-      : _daos = daos;
+      {this.refresh = false, this.filterStatus = FilterStatus.active});
 
   @override
   @JsonKey()
   final bool refresh;
-  final List<DaoData>? _daos;
-  @override
-  List<DaoData>? get daos {
-    final value = _daos;
-    if (value == null) return null;
-    if (_daos is EqualUnmodifiableListView) return _daos;
-    // ignore: implicit_dynamic_type
-    return EqualUnmodifiableListView(value);
-  }
-
   @override
   @JsonKey()
   final FilterStatus filterStatus;
 
   @override
   String toString() {
-    return 'ProposalsEvent.initial(refresh: $refresh, daos: $daos, filterStatus: $filterStatus)';
+    return 'ProposalsEvent.initial(refresh: $refresh, filterStatus: $filterStatus)';
   }
 
   @override
@@ -192,14 +162,12 @@ class _$InitialImpl implements _Initial {
         (other.runtimeType == runtimeType &&
             other is _$InitialImpl &&
             (identical(other.refresh, refresh) || other.refresh == refresh) &&
-            const DeepCollectionEquality().equals(other._daos, _daos) &&
             (identical(other.filterStatus, filterStatus) ||
                 other.filterStatus == filterStatus));
   }
 
   @override
-  int get hashCode => Object.hash(runtimeType, refresh,
-      const DeepCollectionEquality().hash(_daos), filterStatus);
+  int get hashCode => Object.hash(runtimeType, refresh, filterStatus);
 
   /// Create a copy of ProposalsEvent
   /// with the given fields replaced by the non-null parameter values.
@@ -212,33 +180,27 @@ class _$InitialImpl implements _Initial {
   @override
   @optionalTypeArgs
   TResult when<TResult extends Object?>({
-    required TResult Function(
-            bool refresh, List<DaoData>? daos, FilterStatus filterStatus)
-        initial,
+    required TResult Function(bool refresh, FilterStatus filterStatus) initial,
   }) {
-    return initial(refresh, daos, filterStatus);
+    return initial(refresh, filterStatus);
   }
 
   @override
   @optionalTypeArgs
   TResult? whenOrNull<TResult extends Object?>({
-    TResult? Function(
-            bool refresh, List<DaoData>? daos, FilterStatus filterStatus)?
-        initial,
+    TResult? Function(bool refresh, FilterStatus filterStatus)? initial,
   }) {
-    return initial?.call(refresh, daos, filterStatus);
+    return initial?.call(refresh, filterStatus);
   }
 
   @override
   @optionalTypeArgs
   TResult maybeWhen<TResult extends Object?>({
-    TResult Function(
-            bool refresh, List<DaoData>? daos, FilterStatus filterStatus)?
-        initial,
+    TResult Function(bool refresh, FilterStatus filterStatus)? initial,
     required TResult orElse(),
   }) {
     if (initial != null) {
-      return initial(refresh, daos, filterStatus);
+      return initial(refresh, filterStatus);
     }
     return orElse();
   }
@@ -274,14 +236,10 @@ class _$InitialImpl implements _Initial {
 
 abstract class _Initial implements ProposalsEvent {
   const factory _Initial(
-      {final bool refresh,
-      final List<DaoData>? daos,
-      final FilterStatus filterStatus}) = _$InitialImpl;
+      {final bool refresh, final FilterStatus filterStatus}) = _$InitialImpl;
 
   @override
   bool get refresh;
-  @override
-  List<DaoData>? get daos;
   @override
   FilterStatus get filterStatus;
 

--- a/lib/ui/proposals/list/interactor/proposals_event.dart
+++ b/lib/ui/proposals/list/interactor/proposals_event.dart
@@ -4,7 +4,6 @@ part of 'proposals_bloc.dart';
 class ProposalsEvent with _$ProposalsEvent {
   const factory ProposalsEvent.initial({
     @Default(false) bool refresh,
-    List<DaoData>? daos,
     @Default(FilterStatus.active) FilterStatus filterStatus,
   }) = _Initial;
 }


### PR DESCRIPTION
## Scope

[Ticket](https://github.com/hypha-dao/hypha-wallet/issues/329)

I fixed the DAOs `ordering` on the `Filter Proposals` page and enabled the ability to `deselect` a DAO. The `proposals count` under each DAO now updates correctly.