### PR TITLE
fix: adjust app bar elevation

### DIFF
--- a/lib/ui/proposals/history/components/proposals_history_view.dart
+++ b/lib/ui/proposals/history/components/proposals_history_view.dart
@@ -14,6 +14,7 @@ class ProposalsHistoryView extends StatelessWidget {
     return Scaffold(
         backgroundColor: context.isDarkMode ? HyphaColors.darkBlack : HyphaColors.offWhite,
         appBar: AppBar(
+          scrolledUnderElevation: 0,
           title: const Text('Proposals History'),
         ),
         body: RefreshIndicator(


### PR DESCRIPTION
## Scope

[Ticket](https://github.com/hypha-dao/hypha-wallet/issues/335)

I set `scrolledUnderElevation` to `0` to fix the `app bar color change`.