### PR TITLE
feat: Implemented navigation logic and dependency exchange for proposal creation steps

### DIFF
--- a/lib/core/di/bloc_module.dart
+++ b/lib/core/di/bloc_module.dart
@@ -46,7 +46,8 @@ void _registerBlocsModule() {
         _getIt<RemoveAvatarUseCase>(),
       ));
   _registerFactoryWithParams<SignTransactionBloc, ScanQrCodeResultData, void>(
-    (qrCodeData, _) => SignTransactionBloc(_getIt<SignTransactionUseCase>(), qrCodeData),
+    (qrCodeData, _) =>
+        SignTransactionBloc(_getIt<SignTransactionUseCase>(), qrCodeData),
   );
   _registerFactory(() => TransactionsBloc(
         _getIt<GetTransactionHistoryUseCase>(),
@@ -135,25 +136,24 @@ void _registerBlocsModule() {
       ));
 
   _registerLazySingleton(() => ProposalsBloc(
-    _getIt<GetProposalsUseCase>(),
-    _getIt<FetchProfileUseCase>(),
-    _getIt<ErrorHandlerManager>(),
-  ));
+        _getIt<GetProposalsUseCase>(),
+        _getIt<FetchProfileUseCase>(),
+        _getIt<ErrorHandlerManager>(),
+      ));
 
   _registerLazySingleton(() => FilterProposalsBloc(
-    _getIt<ProposalsBloc>(),
-    _getIt<FetchProfileUseCase>(),
-    _getIt<AggregateDaoProposalCountsUseCase>(),
-    _getIt<ErrorHandlerManager>(),
-  ));
+        _getIt<ProposalsBloc>(),
+        _getIt<FetchProfileUseCase>(),
+        _getIt<AggregateDaoProposalCountsUseCase>(),
+        _getIt<ErrorHandlerManager>(),
+      ));
 
   _registerFactoryWithParams<ProposalsHistoryBloc, DaoData, void>(
-        (dao, _) => ProposalsHistoryBloc(
-      _getIt<GetProposalsUseCase>(),
-      _getIt<ErrorHandlerManager>(),
-            dao
-    ),
+    (dao, _) => ProposalsHistoryBloc(
+        _getIt<GetProposalsUseCase>(), _getIt<ErrorHandlerManager>(), dao),
   );
 
-  _registerFactory(() => ProposalCreationBloc());
+  _registerFactoryWithParams<ProposalCreationBloc, List<DaoData>, void>(
+    (daos, _) => ProposalCreationBloc(daos),
+  );
 }

--- a/lib/core/network/models/outcome_model.dart
+++ b/lib/core/network/models/outcome_model.dart
@@ -1,8 +1,27 @@
 import 'package:flutter/cupertino.dart';
 
+enum OutcomeType {
+  agreement,
+  oneTimePayment,
+  recurringPayment,
+}
+
+extension OutcomeTypeExtension on OutcomeType {
+  String get label {
+    switch (this) {
+      case OutcomeType.agreement:
+        return 'Agreement';
+      case OutcomeType.oneTimePayment:
+        return 'One Time Payment';
+      case OutcomeType.recurringPayment:
+        return 'Recurring Payment';
+    }
+  }
+}
+
 class OutcomeModel {
   final IconData icon;
-  final String type;
+  final OutcomeType type;
   final String details;
 
   OutcomeModel({required this.icon, required this.type, required this.details});

--- a/lib/core/network/models/proposal_creation_model.dart
+++ b/lib/core/network/models/proposal_creation_model.dart
@@ -1,15 +1,22 @@
+import 'package:hypha_wallet/core/network/models/dao_data_model.dart';
+
 class ProposalCreationModel {
   final String? id;
   final String? title;
   final String? details;
+  final DaoData? dao;
+  final String? type;
 
-  ProposalCreationModel({this.id, this.title, this.details});
+  ProposalCreationModel(
+      {this.type, this.dao, this.id, this.title, this.details});
 
   ProposalCreationModel copyWith(Map<String, dynamic> updates) {
     return ProposalCreationModel(
       id: updates.containsKey('id') ? updates['id'] : id,
       title: updates.containsKey('title') ? updates['title'] : title,
       details: updates.containsKey('details') ? updates['details'] : details,
+      dao: updates.containsKey('dao') ? updates['dao'] : dao,
+      type: updates.containsKey('type') ? updates['type'] : type,
     );
   }
 }

--- a/lib/design/cards/hypha_option_card.dart
+++ b/lib/design/cards/hypha_option_card.dart
@@ -11,19 +11,25 @@ class HyphaOptionCard extends StatelessWidget {
   final String? subTitle;
   final dynamic valueNotifier;
   final int index;
+  final Function()? onTap;
 
   const HyphaOptionCard(this.valueNotifier, this.index,
-      {this.dao, this.title, this.subTitle, super.key});
+      {this.dao, this.title, this.subTitle, super.key, this.onTap});
 
   @override
   Widget build(BuildContext context) {
     return GestureDetector(
       onTap: () {
+
+
         if (valueNotifier.value != index) {
           valueNotifier.value = index;
+
         } else if (subTitle != null) {
           valueNotifier.value = null;
         }
+
+        onTap?.call();
       },
       child: HyphaCard(
           child: Container(

--- a/lib/ui/proposals/creation/components/dao_selection_view.dart
+++ b/lib/ui/proposals/creation/components/dao_selection_view.dart
@@ -1,10 +1,12 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:get/get.dart';
 import 'package:get_it/get_it.dart';
 import 'package:hypha_wallet/core/network/models/dao_data_model.dart';
 import 'package:hypha_wallet/design/cards/hypha_option_card.dart';
 import 'package:hypha_wallet/design/hypha_colors.dart';
 import 'package:hypha_wallet/design/themes/extensions/theme_extension_provider.dart';
+import 'package:hypha_wallet/ui/proposals/creation/interactor/proposal_creation_bloc.dart';
 import 'package:hypha_wallet/ui/proposals/list/interactor/proposals_bloc.dart';
 
 class DaoSelectionView extends StatefulWidget {
@@ -16,12 +18,25 @@ class DaoSelectionView extends StatefulWidget {
 
 class _DaoSelectionViewState extends State<DaoSelectionView> {
   late List<DaoData> daos;
-  final ValueNotifier<int> selectedDaoIndexNotifier = ValueNotifier<int>(0);
+  late final ValueNotifier<int> selectedDaoIndexNotifier;
 
   @override
   void initState() {
     super.initState();
     daos = GetIt.I.get<ProposalsBloc>().daos;
+    final ProposalCreationBloc proposalCreationBloc =
+        context.read<ProposalCreationBloc>();
+    if (proposalCreationBloc.state.proposal?.dao == null) {
+      selectedDaoIndexNotifier = ValueNotifier<int>(0);
+      proposalCreationBloc.add(
+        ProposalCreationEvent.updateProposal(
+          {'dao': daos.first},
+        ),
+      );
+    } else {
+      selectedDaoIndexNotifier = ValueNotifier<int>(
+          daos.indexOf(proposalCreationBloc.state.proposal!.dao!));
+    }
   }
 
   @override
@@ -52,8 +67,11 @@ class _DaoSelectionViewState extends State<DaoSelectionView> {
             (index) {
               return Container(
                 margin: const EdgeInsets.symmetric(vertical: 10),
-                child: HyphaOptionCard(
-                    dao: daos[index], selectedDaoIndexNotifier, index),
+                child: HyphaOptionCard(onTap: () {
+                  context.read<ProposalCreationBloc>().add(
+                      ProposalCreationEvent.updateProposal(
+                          {'dao': daos[index]}));
+                }, dao: daos[index], selectedDaoIndexNotifier, index),
               );
             },
           )

--- a/lib/ui/proposals/creation/components/hypha_outcome_card.dart
+++ b/lib/ui/proposals/creation/components/hypha_outcome_card.dart
@@ -1,78 +1,85 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:hypha_wallet/core/network/models/outcome_model.dart';
 import 'package:hypha_wallet/design/hypha_card.dart';
 import 'package:hypha_wallet/design/hypha_colors.dart';
 import 'package:hypha_wallet/design/themes/extensions/theme_extension_provider.dart';
+import 'package:hypha_wallet/ui/proposals/creation/interactor/proposal_creation_bloc.dart';
 
 class HyphaOutcomeCard extends StatelessWidget {
   final OutcomeModel outcomeModel;
-  final dynamic valueNotifier;
+  final ValueNotifier<int> valueNotifier;
   final int index;
 
-  const HyphaOutcomeCard(this.outcomeModel, this.valueNotifier, this.index,
-      {super.key});
+  const HyphaOutcomeCard(
+    this.outcomeModel,
+    this.valueNotifier,
+    this.index, {
+    super.key,
+  });
 
   @override
   Widget build(BuildContext context) {
     return GestureDetector(
       onTap: () {
-        if (valueNotifier.value != index) {
-          valueNotifier.value = index;
-        }
+        valueNotifier.value = index;
+        context.read<ProposalCreationBloc>().add(
+              ProposalCreationEvent.updateProposal(
+                {'type': outcomeModel.type.label},
+              ),
+            );
       },
       child: HyphaCard(
-          child: Container(
-        padding: const EdgeInsets.symmetric(vertical: 15, horizontal: 20),
-        child: Column(
-          children: [
-            Row(
-              children: [
-                Transform.rotate(
-                  angle: index == 1 ? -3.14 / 3 : 0,
-                  child: Icon(
-                    outcomeModel.icon,
-                    color: HyphaColors.primaryBlu,
-                    size: 24,
+        child: Container(
+          padding: const EdgeInsets.symmetric(vertical: 15, horizontal: 20),
+          child: Column(
+            children: [
+              Row(
+                children: [
+                  Transform.rotate(
+                    angle: index == 1 ? -3.14 / 3 : 0,
+                    child: Icon(
+                      outcomeModel.icon,
+                      color: HyphaColors.primaryBlu,
+                      size: 24,
+                    ),
                   ),
-                ),
-                const SizedBox(
-                  width: 6,
-                ),
-                Text(
-                  outcomeModel.type,
-                  style: context.hyphaTextTheme.smallTitles,
-                ),
-                const Spacer(),
-                ValueListenableBuilder<dynamic>(
-                  valueListenable: valueNotifier,
-                  builder: (context, selectedIndex, child) {
-                    return CircleAvatar(
-                      radius: 12,
-                      backgroundColor: selectedIndex == index
-                          ? HyphaColors.primaryBlu
-                          : HyphaColors.midGrey.withOpacity(.3),
-                      child: CircleAvatar(
-                        radius: selectedIndex == index ? 4 : 10.5,
+                  const SizedBox(width: 6),
+                  Text(
+                    outcomeModel.type.label,
+                    style: context.hyphaTextTheme.smallTitles,
+                  ),
+                  const Spacer(),
+                  ValueListenableBuilder<int>(
+                    valueListenable: valueNotifier,
+                    builder: (context, selectedIndex, child) {
+                      return CircleAvatar(
+                        radius: 12,
                         backgroundColor: selectedIndex == index
-                            ? HyphaColors.white
-                            : HyphaColors.lightBlack,
-                      ),
-                    );
-                  },
+                            ? HyphaColors.primaryBlu
+                            : HyphaColors.midGrey.withOpacity(.3),
+                        child: CircleAvatar(
+                          radius: selectedIndex == index ? 4 : 10.5,
+                          backgroundColor: selectedIndex == index
+                              ? HyphaColors.white
+                              : HyphaColors.lightBlack,
+                        ),
+                      );
+                    },
+                  ),
+                ],
+              ),
+              const SizedBox(height: 15),
+              Text(
+                outcomeModel.details,
+                style: context.hyphaTextTheme.ralMediumBody.copyWith(
+                  color: HyphaColors.midGrey,
                 ),
-              ],
-            ),
-            const SizedBox(
-              height: 15,
-            ),
-            Text(
-              outcomeModel.details,
-              style: context.hyphaTextTheme.ralMediumBody
-                  .copyWith(color: HyphaColors.midGrey),
-            ),
-          ],
+              ),
+            ],
+          ),
         ),
-      )),
+      ),
     );
   }
 }

--- a/lib/ui/proposals/creation/components/outcome_selection_view.dart
+++ b/lib/ui/proposals/creation/components/outcome_selection_view.dart
@@ -1,33 +1,62 @@
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:get/get.dart';
 import 'package:hypha_wallet/core/network/models/outcome_model.dart';
 import 'package:hypha_wallet/design/hypha_colors.dart';
 import 'package:hypha_wallet/design/themes/extensions/theme_extension_provider.dart';
 import 'package:hypha_wallet/ui/proposals/creation/components/hypha_outcome_card.dart';
+import 'package:hypha_wallet/ui/proposals/creation/interactor/proposal_creation_bloc.dart';
 
-class DaoSelectionView extends StatelessWidget {
-   DaoSelectionView({super.key});
+class OutcomeSelectionView extends StatefulWidget {
+  const OutcomeSelectionView({super.key});
 
-   final List<OutcomeModel> outcomeTypes = [
+  @override
+  State<OutcomeSelectionView> createState() => _OutcomeSelectionViewState();
+}
+
+class _OutcomeSelectionViewState extends State<OutcomeSelectionView> {
+  final List<OutcomeModel> outcomeTypes = [
     OutcomeModel(
-        icon: CupertinoIcons.hand_thumbsup,
-        type: 'Agreement',
-        details:
-            'A Proposal where other DAO members are simply asked to vote Yes or No.'),
+      icon: CupertinoIcons.hand_thumbsup,
+      type: OutcomeType.agreement,
+      details:
+          'A Proposal where other DAO members are simply asked to vote Yes or No.',
+    ),
     OutcomeModel(
-        icon: Icons.fiber_smart_record_outlined,
-        type: 'One Time Payment',
-        details:
-            'Attach a payment request to your proposal.  You will be asked to chose a token and specify  an amount in a following step.'),
+      icon: Icons.fiber_smart_record_outlined,
+      type: OutcomeType.oneTimePayment,
+      details:
+          'Attach a payment request to your proposal. You will be asked to choose a token and specify an amount in a following step.',
+    ),
     OutcomeModel(
-        icon: Icons.calendar_month_outlined,
-        type: 'Recurring Payment',
-        details:
-            'Think at this outcome as something like a job position. You will be asked to define token, duration and amount per week or month in a following step.'),
+      icon: Icons.calendar_month_outlined,
+      type: OutcomeType.recurringPayment,
+      details:
+          'Think of this outcome as something like a job position. You will be asked to define token, duration, and amount per week or month in a following step.',
+    ),
   ];
 
-  final ValueNotifier<int> selectedTypeIndexNotifier = ValueNotifier<int>(0);
+  late final ValueNotifier<int> selectedTypeIndexNotifier;
+
+  @override
+  void initState() {
+    super.initState();
+    final ProposalCreationBloc proposalCreationBloc =
+        context.read<ProposalCreationBloc>();
+    if (proposalCreationBloc.state.proposal?.type == null) {
+      selectedTypeIndexNotifier = ValueNotifier<int>(0);
+      context.read<ProposalCreationBloc>().add(
+            ProposalCreationEvent.updateProposal(
+              {'type': outcomeTypes.first.type.label},
+            ),
+          );
+    } else {
+      selectedTypeIndexNotifier = ValueNotifier<int>(outcomeTypes.indexWhere(
+          (outcome) =>
+              outcome.type.label == proposalCreationBloc.state.proposal?.type));
+    }
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -41,15 +70,17 @@ class DaoSelectionView extends StatelessWidget {
           const SizedBox(height: 20),
           Text(
             'Outcome',
-            style: context.hyphaTextTheme.smallTitles
-                .copyWith(color: HyphaColors.primaryBlu),
+            style: context.hyphaTextTheme.smallTitles.copyWith(
+              color: HyphaColors.primaryBlu,
+            ),
           ),
           Padding(
             padding: const EdgeInsets.only(top: 20, bottom: 30),
             child: Text(
               'This last step allows you to choose among three types of outcome for your proposal.',
-              style: context.hyphaTextTheme.ralMediumBody
-                  .copyWith(color: HyphaColors.midGrey),
+              style: context.hyphaTextTheme.ralMediumBody.copyWith(
+                color: HyphaColors.midGrey,
+              ),
             ),
           ),
           ...List.generate(
@@ -58,10 +89,13 @@ class DaoSelectionView extends StatelessWidget {
               return Container(
                 margin: const EdgeInsets.symmetric(vertical: 10),
                 child: HyphaOutcomeCard(
-                    outcomeTypes[index], selectedTypeIndexNotifier, index),
+                  outcomeTypes[index],
+                  selectedTypeIndexNotifier,
+                  index,
+                ),
               );
             },
-          )
+          ),
         ],
       ),
     );

--- a/lib/ui/proposals/creation/components/proposal_review_view.dart
+++ b/lib/ui/proposals/creation/components/proposal_review_view.dart
@@ -38,18 +38,11 @@ class ProposalReviewView extends StatelessWidget {
                           crossAxisAlignment: CrossAxisAlignment.start,
                           children: [
                             const SizedBox(height: 20),
-                            const Row(
+                             Row(
                               children: [
                                 Expanded(
                                   child: ProposalHeader(
-                                    DaoData(
-                                      docId: 21345,
-                                      detailsDaoName: '',
-                                      settingsDaoTitle: 'HyphaDao',
-                                      logoIPFSHash: '',
-                                      logoType: '',
-                                      settingsDaoUrl: '',
-                                    ),
+                                    state.proposal!.dao,
                                     text: 'Builders',
                                   ),
                                 ),

--- a/lib/ui/proposals/creation/interactor/proposal_creation_bloc.dart
+++ b/lib/ui/proposals/creation/interactor/proposal_creation_bloc.dart
@@ -2,30 +2,44 @@ import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:freezed_annotation/freezed_annotation.dart';
 import 'package:hypha_wallet/core/error_handler/model/hypha_error.dart';
-import 'package:hypha_wallet/core/error_handler/model/hypha_error_type.dart';
+import 'package:hypha_wallet/core/network/models/dao_data_model.dart';
+import 'package:hypha_wallet/core/network/models/outcome_model.dart';
 import 'package:hypha_wallet/core/network/models/proposal_creation_model.dart';
 
 part 'page_command.dart';
+
 part 'proposal_creation_bloc.freezed.dart';
+
 part 'proposal_creation_event.dart';
+
 part 'proposal_creation_state.dart';
 
 class ProposalCreationBloc
     extends Bloc<ProposalCreationEvent, ProposalCreationState> {
-  ProposalCreationBloc() : super(ProposalCreationState(proposal: ProposalCreationModel())) {
+  final List<DaoData> daos;
+
+  ProposalCreationBloc(this.daos)
+      : super(ProposalCreationState(proposal: ProposalCreationModel())) {
     on<_UpdateCurrentView>(_updateCurrentView);
     on<_UpdateProposal>(_updateProposal);
     on<_PublishProposal>(_publishProposal);
     on<_ClearPageCommand>((_, emit) => emit(state.copyWith(command: null)));
+    _pageController = PageController(initialPage: daos.length > 1 ? 0 : 1);
+    if (daos.length == 1) {
+      emit(state.copyWith(
+          proposal: state.proposal!.copyWith({'dao': daos.first})));
+    }
   }
 
-  // TODO(Saif): pass initialPage as parameter
-  final PageController _pageController = PageController(initialPage: 0);
+  late final PageController _pageController;
+
   PageController get pageController => _pageController;
 
-  Future<void> _updateCurrentView(_UpdateCurrentView event, Emitter<ProposalCreationState> emit) async {
+  Future<void> _updateCurrentView(
+      _UpdateCurrentView event, Emitter<ProposalCreationState> emit) async {
     if (event.nextViewIndex == -1) {
-      emit(state.copyWith(command: const PageCommand.navigateBackToProposals()));
+      emit(
+          state.copyWith(command: const PageCommand.navigateBackToProposals()));
     } else {
       switch (event.nextViewIndex) {
         case 0:
@@ -35,14 +49,22 @@ class ProposalCreationBloc
           navigate(emit, event.nextViewIndex);
           break;
         case 2:
-          if(state.proposal!.title != null && state.proposal!.details != null) {
+          if (state.proposal!.title != null &&
+              state.proposal!.details != null) {
             navigate(emit, event.nextViewIndex);
           }
           break;
         case 3:
-          navigate(emit, event.nextViewIndex);
+          navigate(
+              emit,
+              state.proposal!.type == OutcomeType.agreement.label
+                  ? event.nextViewIndex + 1
+                  : event.nextViewIndex);
           break;
         case 4:
+          navigate(emit, event.nextViewIndex);
+          break;
+        case 5:
           navigate(emit, event.nextViewIndex);
           break;
         default:
@@ -60,12 +82,15 @@ class ProposalCreationBloc
     );
   }
 
-  Future<void> _updateProposal(_UpdateProposal event, Emitter<ProposalCreationState> emit) async {
-    final ProposalCreationModel proposal = state.proposal!.copyWith(event.updates);
+  Future<void> _updateProposal(
+      _UpdateProposal event, Emitter<ProposalCreationState> emit) async {
+    final ProposalCreationModel proposal =
+        state.proposal!.copyWith(event.updates);
     emit(state.copyWith(proposal: proposal));
-    }
+  }
 
-  Future<void> _publishProposal(_PublishProposal event, Emitter<ProposalCreationState> emit) async {
+  Future<void> _publishProposal(
+      _PublishProposal event, Emitter<ProposalCreationState> emit) async {
     // TODO(Zied): Implement proposal creation logic
   }
 }

--- a/lib/ui/proposals/creation/proposal_creation_page.dart
+++ b/lib/ui/proposals/creation/proposal_creation_page.dart
@@ -3,26 +3,34 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:get/get.dart';
 import 'package:get_it/get_it.dart';
 import 'package:hypha_wallet/core/error_handler/model/hypha_error.dart';
+import 'package:hypha_wallet/core/network/models/dao_data_model.dart';
+import 'package:hypha_wallet/core/network/models/outcome_model.dart';
 import 'package:hypha_wallet/design/hypha_colors.dart';
-import 'package:hypha_wallet/ui/sign_transaction/failed/sign_transaction_failed_page.dart';
-import 'package:hypha_wallet/ui/sign_transaction/success/sign_transaction_success_page.dart';
 import 'package:hypha_wallet/design/themes/extensions/theme_extension_provider.dart';
+import 'package:hypha_wallet/ui/proposals/creation/components/dao_selection_view.dart';
+import 'package:hypha_wallet/ui/proposals/creation/components/outcome_selection_view.dart';
 import 'package:hypha_wallet/ui/proposals/creation/components/proposal_content_view.dart';
 import 'package:hypha_wallet/ui/proposals/creation/components/proposal_review_view.dart';
 import 'package:hypha_wallet/ui/proposals/creation/interactor/proposal_creation_bloc.dart';
+import 'package:hypha_wallet/ui/sign_transaction/failed/sign_transaction_failed_page.dart';
+import 'package:hypha_wallet/ui/sign_transaction/success/sign_transaction_success_page.dart';
 import 'package:smooth_page_indicator/smooth_page_indicator.dart';
 import 'package:tuple/tuple.dart';
 
 class ProposalCreationPage extends StatelessWidget {
-  const ProposalCreationPage({super.key});
+  const ProposalCreationPage(this.daos, {super.key});
 
-  Tuple2<LinearGradient?, Color?> getGradientAndColor(BuildContext context, int iconIndex, ProposalCreationState state) {
+  final List<DaoData> daos;
+
+  Tuple2<LinearGradient?, Color?> getGradientAndColor(
+      BuildContext context, int iconIndex, ProposalCreationState state) {
     LinearGradient? gradient;
     Color? color;
 
     if (iconIndex == 1) {
       // TODO(Zied-Saif): add other conditions
-      if(state.currentViewIndex == 1 && (state.proposal?.details == null || state.proposal?.title == null)) {
+      if (state.currentViewIndex == 1 &&
+          (state.proposal?.details == null || state.proposal?.title == null)) {
         // TODO(Saif): add a new gradient (not clickable)
         gradient = HyphaColors.gradientBlack;
       } else {
@@ -38,7 +46,7 @@ class ProposalCreationPage extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return BlocProvider(
-      create: (context) => GetIt.I.get<ProposalCreationBloc>(),
+      create: (context) => GetIt.I.get<ProposalCreationBloc>(param1: daos),
       child: BlocConsumer<ProposalCreationBloc, ProposalCreationState>(
         listenWhen: (previous, current) => previous.command != current.command,
         listener: (context, state) {
@@ -47,7 +55,9 @@ class ProposalCreationPage extends StatelessWidget {
               Get.back();
             },
             navigateToSuccessPage: () {
-              Get.to(SignTransactionSuccessPage(transactionType: SignSuccessTransactionType.published, proposalId: state.proposal!.id));
+              Get.to(SignTransactionSuccessPage(
+                  transactionType: SignSuccessTransactionType.published,
+                  proposalId: state.proposal!.id));
             },
             navigateToFailurePage: (HyphaError hyphaError) {
               // TODO(Zied): pass text1 and text2
@@ -55,7 +65,9 @@ class ProposalCreationPage extends StatelessWidget {
             },
           );
 
-          context.read<ProposalCreationBloc>().add(const ProposalCreationEvent.clearPageCommand());
+          context
+              .read<ProposalCreationBloc>()
+              .add(const ProposalCreationEvent.clearPageCommand());
         },
         builder: (context, state) {
           return Scaffold(
@@ -71,17 +83,19 @@ class ProposalCreationPage extends StatelessWidget {
                   Column(
                     crossAxisAlignment: CrossAxisAlignment.start,
                     children: [
-                      if(state.currentViewIndex != 4)
-                      SmoothPageIndicator(
-                        controller: context.read<ProposalCreationBloc>().pageController,
-                        count: 4,
-                        effect: SlideEffect(
-                          dotHeight: 10.0,
-                          dotWidth: 10.0,
-                          activeDotColor: HyphaColors.primaryBlu,
-                          dotColor: HyphaColors.lightBlue.withOpacity(.2),
+                      if (state.currentViewIndex != 4)
+                        SmoothPageIndicator(
+                          controller: context
+                              .read<ProposalCreationBloc>()
+                              .pageController,
+                          count: 4,
+                          effect: SlideEffect(
+                            dotHeight: 10.0,
+                            dotWidth: 10.0,
+                            activeDotColor: HyphaColors.primaryBlu,
+                            dotColor: HyphaColors.lightBlue.withOpacity(.2),
+                          ),
                         ),
-                      ),
                       const SizedBox(height: 10),
                       Text(
                         state.currentViewIndex == 4
@@ -93,37 +107,47 @@ class ProposalCreationPage extends StatelessWidget {
                   ),
                   const Spacer(),
                   ...List.generate(state.currentViewIndex == 4 ? 1 : 2,
-                          (index) {
-                            final Tuple2<LinearGradient?, Color?> tuple2 = getGradientAndColor(context, index, state);
-                        return GestureDetector(
-                          onTap: () {
-                            final nextIndex = state.currentViewIndex + (index == 0 ? -1 : 1);
-                            if (nextIndex >= -1) {
-                              context.read<ProposalCreationBloc>().add(ProposalCreationEvent.updateCurrentView(nextIndex));
-                            }
-                          },
-                          child: Container(
-                            margin: const EdgeInsets.only(left: 10),
-                            height: 40,
-                            width: 40,
-                            decoration: BoxDecoration(
-                              gradient: tuple2.item1,
-                              color: tuple2.item2,
-                              borderRadius: BorderRadius.circular(8.0),
-                            ),
-                            child: Padding(
-                              padding: EdgeInsets.only(left: index == 0 ? 6 : 0),
-                              child: Icon(
-                                index == 0
-                                    ? Icons.arrow_back_ios
-                                    : Icons.arrow_forward_ios,
-                                size: 18,
-                                color: HyphaColors.offWhite,
-                              ),
-                            ),
+                      (index) {
+                    final Tuple2<LinearGradient?, Color?> tuple2 =
+                        getGradientAndColor(context, index, state);
+                    return GestureDetector(
+                      onTap: () {
+                        print('hello');
+                        int nextIndex =
+                            state.currentViewIndex + (index == 0 ? -1 : 1);
+                        print(state.currentViewIndex);
+                        print(nextIndex);
+                        if (nextIndex == 3 &&
+                            state.currentViewIndex == 4 &&
+                            state.proposal?.type ==
+                                OutcomeType.agreement.label) {
+                          nextIndex--;
+                        }
+                        context.read<ProposalCreationBloc>().add(
+                            ProposalCreationEvent.updateCurrentView(nextIndex));
+                      },
+                      child: Container(
+                        margin: const EdgeInsets.only(left: 10),
+                        height: 40,
+                        width: 40,
+                        decoration: BoxDecoration(
+                          gradient: tuple2.item1,
+                          color: tuple2.item2,
+                          borderRadius: BorderRadius.circular(8.0),
+                        ),
+                        child: Padding(
+                          padding: EdgeInsets.only(left: index == 0 ? 6 : 0),
+                          child: Icon(
+                            index == 0
+                                ? Icons.arrow_back_ios
+                                : Icons.arrow_forward_ios,
+                            size: 18,
+                            color: HyphaColors.offWhite,
                           ),
-                        );
-                      })
+                        ),
+                      ),
+                    );
+                  })
                 ],
               ),
             ),
@@ -131,9 +155,9 @@ class ProposalCreationPage extends StatelessWidget {
               controller: context.read<ProposalCreationBloc>().pageController,
               physics: const NeverScrollableScrollPhysics(),
               children: [
-                Container(),
+                const DaoSelectionView(),
                 const ProposalContentView(),
-                Container(),
+                const OutcomeSelectionView(),
                 Container(),
                 const ProposalReviewView(),
               ],

--- a/lib/ui/proposals/list/components/proposals_view.dart
+++ b/lib/ui/proposals/list/components/proposals_view.dart
@@ -26,6 +26,7 @@ class ProposalsView extends StatelessWidget {
   Widget build(BuildContext context) {
     final FilterStatus filterStatus =
         context.watch<ProposalsBloc>().filterStatus;
+    final ProposalsBloc proposalBloc=context.read<ProposalsBloc>();
     return BlocBuilder<ProposalsBloc, ProposalsState>(
         builder: (context, state) {
       return HyphaPageBackground(
@@ -173,10 +174,11 @@ class ProposalsView extends StatelessWidget {
                     },
                   ),
                 )),
-            floatingActionButton:context
-                .read<ProposalsBloc>().daos.isEmpty?null: IconButton(
+            floatingActionButton:proposalBloc.daos.isEmpty?null: IconButton(
                 onPressed: () {
-                  GetX.Get.to(() => const ProposalCreationPage(), transition: GetX.Transition.leftToRight);
+
+                    GetX.Get.to(() =>  ProposalCreationPage(proposalBloc.daos), transition: GetX.Transition.leftToRight);
+
                 },
                 icon: const CircleAvatar(
                     radius: 30,

--- a/lib/ui/proposals/list/interactor/proposals_bloc.dart
+++ b/lib/ui/proposals/list/interactor/proposals_bloc.dart
@@ -49,7 +49,6 @@ class ProposalsBloc extends Bloc<ProposalsEvent, ProposalsState> {
 
     if (profileResult.isValue && profileResult.asValue!.value.daos.isNotEmpty) {
       daos = profileResult.asValue!.value.daos;
-
       // Fetch Proposals using the fetched DAOs
       final Result<List<ProposalModel>, HyphaError> proposalsResult =
           await _getProposalsUseCase


### PR DESCRIPTION
This PR integrates the logic of proposal creation with the UI across all steps by centralizing state management using ProposalCreationBloc. Each screen now consumes data from previous steps, allowing for seamless navigation and dynamic UI updates. User selections, such as the outcome type, are passed forward. Bloc events efficiently handle interactions, ensuring data persistence and maintaining a single source of truth. Refactoring components like HyphaOutcomeCard for direct bloc interaction enhances code reusability and maintainability

## Screenshots
Before            |  After
:-------------------------:|:-------------------------:
![Before](https://github.com/user-attachments/assets/df07970b-e321-48ad-83c6-1dd7059ec29a)  |  ![After](https://github.com/user-attachments/assets/681eac37-bda7-4a8c-90d1-8ebb79d3397e)