### PR TITLE
refactor: remove proposal type selection page

### DIFF
--- a/lib/ui/proposals/creation/interactor/proposal_creation_bloc.dart
+++ b/lib/ui/proposals/creation/interactor/proposal_creation_bloc.dart
@@ -7,11 +7,8 @@ import 'package:hypha_wallet/core/network/models/outcome_model.dart';
 import 'package:hypha_wallet/core/network/models/proposal_creation_model.dart';
 
 part 'page_command.dart';
-
 part 'proposal_creation_bloc.freezed.dart';
-
 part 'proposal_creation_event.dart';
-
 part 'proposal_creation_state.dart';
 
 class ProposalCreationBloc
@@ -26,8 +23,7 @@ class ProposalCreationBloc
     on<_ClearPageCommand>((_, emit) => emit(state.copyWith(command: null)));
     _pageController = PageController(initialPage: daos.length > 1 ? 0 : 1);
     if (daos.length == 1) {
-      emit(state.copyWith(
-          proposal: state.proposal!.copyWith({'dao': daos.first})));
+      emit(state.copyWith(proposal: state.proposal!.copyWith({'dao': daos.first})));
     }
   }
 
@@ -35,17 +31,12 @@ class ProposalCreationBloc
 
   PageController get pageController => _pageController;
 
-  Future<void> _updateCurrentView(
-      _UpdateCurrentView event, Emitter<ProposalCreationState> emit) async {
+  Future<void> _updateCurrentView(_UpdateCurrentView event, Emitter<ProposalCreationState> emit) async {
     if (event.nextViewIndex == -1) {
-      emit(
-          state.copyWith(command: const PageCommand.navigateBackToProposals()));
+      emit(state.copyWith(command: const PageCommand.navigateBackToProposals()));
     } else {
       switch (event.nextViewIndex) {
-        case 0:
-          navigate(emit, event.nextViewIndex);
-          break;
-        case 1:
+        case 0 || 1 || 4 || 5:
           navigate(emit, event.nextViewIndex);
           break;
         case 2:
@@ -60,12 +51,6 @@ class ProposalCreationBloc
               state.proposal!.type == OutcomeType.agreement.label
                   ? event.nextViewIndex + 1
                   : event.nextViewIndex);
-          break;
-        case 4:
-          navigate(emit, event.nextViewIndex);
-          break;
-        case 5:
-          navigate(emit, event.nextViewIndex);
           break;
         default:
           break;

--- a/lib/ui/proposals/creation/proposal_creation_page.dart
+++ b/lib/ui/proposals/creation/proposal_creation_page.dart
@@ -28,9 +28,7 @@ class ProposalCreationPage extends StatelessWidget {
     Color? color;
 
     if (iconIndex == 1) {
-      // TODO(Zied-Saif): add other conditions
-      if (state.currentViewIndex == 1 &&
-          (state.proposal?.details == null || state.proposal?.title == null)) {
+      if (state.currentViewIndex == 1 && (state.proposal?.details == null || state.proposal?.title == null)) {
         // TODO(Saif): add a new gradient (not clickable)
         gradient = HyphaColors.gradientBlack;
       } else {
@@ -83,12 +81,12 @@ class ProposalCreationPage extends StatelessWidget {
                   Column(
                     crossAxisAlignment: CrossAxisAlignment.start,
                     children: [
-                      if (state.currentViewIndex != 4)
+                      if (state.currentViewIndex != 2)
                         SmoothPageIndicator(
                           controller: context
                               .read<ProposalCreationBloc>()
                               .pageController,
-                          count: 4,
+                          count: 2,
                           effect: SlideEffect(
                             dotHeight: 10.0,
                             dotWidth: 10.0,
@@ -98,7 +96,7 @@ class ProposalCreationPage extends StatelessWidget {
                         ),
                       const SizedBox(height: 10),
                       Text(
-                        state.currentViewIndex == 4
+                        state.currentViewIndex == 2
                             ? 'Review & Publish'
                             : 'Create Proposal',
                         style: context.hyphaTextTheme.mediumTitles,
@@ -106,25 +104,20 @@ class ProposalCreationPage extends StatelessWidget {
                     ],
                   ),
                   const Spacer(),
-                  ...List.generate(state.currentViewIndex == 4 ? 1 : 2,
+                  ...List.generate(state.currentViewIndex == 2 ? 1 : 2,
                       (index) {
                     final Tuple2<LinearGradient?, Color?> tuple2 =
                         getGradientAndColor(context, index, state);
                     return GestureDetector(
                       onTap: () {
-                        print('hello');
-                        int nextIndex =
-                            state.currentViewIndex + (index == 0 ? -1 : 1);
-                        print(state.currentViewIndex);
-                        print(nextIndex);
+                        int nextIndex = state.currentViewIndex + (index == 0 ? -1 : 1);
                         if (nextIndex == 3 &&
                             state.currentViewIndex == 4 &&
                             state.proposal?.type ==
                                 OutcomeType.agreement.label) {
                           nextIndex--;
                         }
-                        context.read<ProposalCreationBloc>().add(
-                            ProposalCreationEvent.updateCurrentView(nextIndex));
+                        context.read<ProposalCreationBloc>().add(ProposalCreationEvent.updateCurrentView(nextIndex));
                       },
                       child: Container(
                         margin: const EdgeInsets.only(left: 10),
@@ -157,8 +150,8 @@ class ProposalCreationPage extends StatelessWidget {
               children: [
                 const DaoSelectionView(),
                 const ProposalContentView(),
-                const OutcomeSelectionView(),
-                Container(),
+                //const OutcomeSelectionView(),
+                //Container(),
                 const ProposalReviewView(),
               ],
             ),

--- a/lib/ui/proposals/creation/proposal_creation_page.dart
+++ b/lib/ui/proposals/creation/proposal_creation_page.dart
@@ -150,8 +150,6 @@ class ProposalCreationPage extends StatelessWidget {
               children: [
                 const DaoSelectionView(),
                 const ProposalContentView(),
-                //const OutcomeSelectionView(),
-                //Container(),
                 const ProposalReviewView(),
               ],
             ),


### PR DESCRIPTION
## Scope

[Ticket](https://github.com/hypha-dao/hypha-wallet/issues/354)

I've removed the proposal type selection page when creating a proposal, as the type is now set to `Agreement` by default.

Before            |  After
:-------------------------:|:-------------------------:
<img src="https://github.com/user-attachments/assets/8976dff5-e584-433b-b6f1-4601cb9b8752" width="200"/> |  <img src="https://github.com/user-attachments/assets/aa43be02-4255-4df8-8ef8-1bc6b955ef03" width="200"/>
