### PR TITLE
fix: proposals loading issue

### DIFF
--- a/lib/ui/proposals/list/proposals_page.dart
+++ b/lib/ui/proposals/list/proposals_page.dart
@@ -9,8 +9,8 @@ class ProposalsPage extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return BlocProvider(
-      create: (context) => GetIt.I.get<ProposalsBloc>()..add(const ProposalsEvent.initial()),
+    return BlocProvider.value(
+      value: GetIt.I.get<ProposalsBloc>()..add(const ProposalsEvent.initial()),
       child: const ProposalsView(),
     );
   }


### PR DESCRIPTION
## Scope

[Ticket](https://github.com/hypha-dao/hypha-wallet/issues/365)

This PR resolves an issue where proposals load infinitely. The problem arises when you scan a QR code or create a proposal, and the app returns you to the first page (bottom navigation). In this case, the initial event for the proposals bloc is triggered again, but the success state is not emitted, resulting in proposals loading indefinitely.